### PR TITLE
Add recipe 093 for browser http use

### DIFF
--- a/src/section_09/recipe093_working_with_browser_library.robot
+++ b/src/section_09/recipe093_working_with_browser_library.robot
@@ -13,10 +13,10 @@ Documentation     PROBLEM:
 ...               $ rfbrowser init
 Library           Collections
 Library           Browser
-Force Tags        py3.7    py3.8    py3.9
+Force Tags        py3.7    py3.8
 
 *** Variables ***
-${recipe}         Recipe 9.1 Working With Browser Library
+${recipe}         Recipe 9.3 Working With Browser Library
 ${level}          Intermediate
 ${category}       External Library: Browser
 

--- a/src/section_09/recipe093_working_with_browser_library.robot
+++ b/src/section_09/recipe093_working_with_browser_library.robot
@@ -1,0 +1,30 @@
+*** Settings ***
+Documentation     PROBLEM:
+...               You want to send a simple HTTP request using Browser library.
+...               DISCUSSION:
+...               Making a request from inside a page context allows use of page
+...               cookies and other headers that maybe difficult to gain without
+...               using browser. This method also detects some cross site problems that
+...               may not occur without a browser.
+...               This recipe demonstrates using keywords from Collections standard library.
+...               This recipe also demonstrates installing and using an external library.
+...               This recipe has the following external dependencies:
+...               $ pip install -U robotframework-browser
+...               $ rfbrowser init
+Library           Collections
+Library           Browser
+Force Tags        py3.7    py3.8    py3.9
+
+*** Variables ***
+${recipe}         Recipe 9.1 Working With Browser Library
+${level}          Intermediate
+${category}       External Library: Browser
+
+*** Test Cases ***
+Get Request
+    New Page    https://www.github.com
+    &{response} =    HTTP    https://api.github.com/users/adrianyorke
+    Should Be Equal    ${response}[status]    ${200}
+    Dictionary Should Not Contain Value    ${response}[body]    The Black Knight
+    Dictionary Should Contain Value    ${response}[body]    Adrian Yorke
+    Dictionary Should Contain Value    ${response}[body]    Helsinki, Finland


### PR DESCRIPTION
Show how to use Browser library to make a simple request.
This method allows cookies and authentication headers from the page being used in the http request.