### PR TITLE
Rename robocop ext_rules argument to ext-rules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
         if: matrix.python-version != 3.6
       - name: Run Robocop
         run:
-          robocop -r rules_by_id  --configure return_status:quality_gate:W=-1 --exclude missing-doc-* --ignore section_99\* --ext_rules tests/robocop_rules.py src
+          robocop -r rules_by_id  --configure return_status:quality_gate:W=-1 --exclude missing-doc-* --ignore section_99\* --ext-rules tests/robocop_rules.py src
         if: always()
       - name: Run Robot tests
         run:


### PR DESCRIPTION
Message sent to robocop team on RF Slack:

"The Cookbook github CI has started to error recently:  "robocop: error: unrecognized arguments: --ext_rules".  I can see the argument been renamed - is there any change in usage or can I just rename to --ext-rules?"